### PR TITLE
Support category sets, character ranges, and repeating categories

### DIFF
--- a/src/main/java/org/xproc/pep/Category.java
+++ b/src/main/java/org/xproc/pep/Category.java
@@ -33,6 +33,7 @@ package org.xproc.pep;
 public class Category {
 	String name;
 	boolean terminal;
+	boolean repeatable;
 	
 	/**
 	 * Special start category for seeding Earley parsers. 
@@ -67,6 +68,19 @@ public class Category {
 	 * <code>null</code> or zero-length.
 	 */
 	public Category(String name, boolean terminal) {
+		this(name, terminal, false);
+	}
+
+	/**
+	 * Creates a new category <code>name</code> with the specified terminal
+	 * status.
+	 * @param name The name for this category.
+	 * @param terminal Whether or not this category is a terminal.
+	 * @param repeatable Whether or not this category can be repeated.
+	 * @throws IllegalArgumentException If <code>name</code> is
+	 * <code>null</code> or zero-length.
+	 */
+	public Category(String name, boolean terminal, boolean repeatable) {
 		if(!terminal && (name == null || name.length() == 0)) {
 			throw new IllegalArgumentException(
 					"empty name specified for category");
@@ -74,6 +88,7 @@ public class Category {
 		
 		this.name = name;
 		this.terminal = terminal;
+		this.repeatable = repeatable;
 	}
 	
 	/**
@@ -95,6 +110,15 @@ public class Category {
 	}
 
 	/**
+	 * Gets the repeatable status of this category.
+	 * @return The repeatable status specified for this category upon
+	 * construction.
+	 */
+	public boolean isRepeatable() {
+		return repeatable;
+	}
+
+	/**
 	 * Tests whether this category is equal to another.
 	 * @return <code>true</code> iff the specified object is an instance
 	 * of <code>Category</code> and its name and terminal status are equal
@@ -109,6 +133,16 @@ public class Category {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Tests whether a given token matches this category.
+	 * @param token The input token.
+	 * @param ignoreCase Should case be ignored?
+	 * @return <code>true</code> iff the token is considered a match for this category.
+	 */
+	public boolean matches(String token, boolean ignoreCase) {
+		return name.equals(token) || (ignoreCase && name.equalsIgnoreCase(token));
 	}
 
 	/**

--- a/src/main/java/org/xproc/pep/CategoryCharacterSet.java
+++ b/src/main/java/org/xproc/pep/CategoryCharacterSet.java
@@ -1,0 +1,92 @@
+package org.xproc.pep;
+
+import java.util.List;
+
+public class CategoryCharacterSet extends Category {
+    private final List<CharacterRange> ranges;
+
+    // FIXME: don't store ranges that are wholly subsumed by other ranges.
+
+    public CategoryCharacterSet(String name, List<CharacterRange> ranges, boolean repeatable) {
+        super(name, true, repeatable);
+        this.ranges = ranges;
+    }
+
+    public CategoryCharacterSet(String name, List<CharacterRange> ranges) {
+        super(name, true, false);
+        this.ranges = ranges;
+    }
+
+    /**
+     * Tests whether this category is equal to another.
+     * @return <code>true</code> iff the specified object is an instance
+     * of <code>CategorySet</code> and its name, terminal status, and tokens are equal
+     * to this category's name, terminal status, and tokens.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof CategoryCharacterSet) {
+            CategoryCharacterSet oc = (CategoryCharacterSet)obj;
+            if (oc != Category.START &&
+                    terminal == oc.terminal && name.equals(oc.name)) {
+                for (CharacterRange range : ranges) {
+                    if (!oc.ranges.contains(range)) {
+                        return false;
+                    }
+                }
+                for (CharacterRange range : oc.ranges) {
+                    if (!ranges.contains(range)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Tests whether a given token matches this category.
+     * @param token The input token.
+     * @param ignoreCase Should case be ignored?
+     * @return <code>true</code> iff the token is considered a match for this category.
+     */
+    @Override
+    public boolean matches(String token, boolean ignoreCase) {
+        if (token.codePointCount(0, token.length()) > 1) {
+            return false;
+        }
+        int cp = token.codePointAt(0);
+        if (ignoreCase) {
+            cp = Character.toUpperCase(cp);
+        }
+        for (CharacterRange range : ranges) {
+            boolean found = cp >= range.getFirst() && cp <= range.getLast();
+            if (ignoreCase) {
+                found = cp >= Character.toUpperCase(range.getFirst()) && cp <= Character.toUpperCase(range.getLast());
+            }
+            if ((found && !range.getNegated()) || (!found && range.getNegated())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        boolean first = true;
+        for (CharacterRange range : ranges) {
+            if (!first) {
+                sb.append(",");
+            }
+            first = false;
+            sb.append(range);
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/xproc/pep/CategorySet.java
+++ b/src/main/java/org/xproc/pep/CategorySet.java
@@ -1,0 +1,100 @@
+package org.xproc.pep;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class CategorySet extends Category {
+    private final boolean negated;
+    private final List<String> tokens;
+
+    public CategorySet(String name, List<String> tokens, boolean negated, boolean repeatable) {
+        super(name, true, repeatable);
+        this.tokens = tokens;
+        this.negated = negated;
+    }
+
+    public CategorySet(String name, List<String> tokens, boolean negated) {
+        super(name, true, false);
+        this.tokens = tokens;
+        this.negated = negated;
+    }
+
+    public CategorySet(String name, List<String> tokens) {
+        super(name, true);
+        this.tokens = tokens;
+        negated = false;
+    }
+
+    /**
+     * Tests whether this category is equal to another.
+     * @return <code>true</code> iff the specified object is an instance
+     * of <code>CategorySet</code> and its name, terminal status, and tokens are equal
+     * to this category's name, terminal status, and tokens.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof CategorySet) {
+            CategorySet oc = (CategorySet)obj;
+            if (oc != Category.START &&
+                    terminal == oc.terminal && name.equals(oc.name)) {
+                HashMap<String,Boolean> myTokens = new HashMap<>();
+                for (String token : tokens) {
+                    myTokens.put(token, false);
+                }
+                for (String token : oc.tokens) {
+                    if (myTokens.containsKey(token)) {
+                        myTokens.put(token, true);
+                    } else {
+                        return false;
+                    }
+                }
+                for (String token : myTokens.keySet()) {
+                    if (!myTokens.get(token)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Tests whether a given token matches this category.
+     * @param token The input token.
+     * @param ignoreCase Should case be ignored?
+     * @return <code>true</code> iff the token is considered a match for this category.
+     */
+    @Override
+    public boolean matches(String token, boolean ignoreCase) {
+        boolean found = false;
+        for (String item : tokens) {
+            found = found || item.equals(token) || (ignoreCase && item.equalsIgnoreCase(token));
+        }
+        if (negated) {
+            return !found;
+        } else {
+            return found;
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (negated) {
+            sb.append("!");
+        }
+        sb.append("{");
+        boolean first = true;
+        for (String token : tokens) {
+            if (!first) {
+                sb.append(",");
+            }
+            first = false;
+            sb.append(token);
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/xproc/pep/CharacterRange.java
+++ b/src/main/java/org/xproc/pep/CharacterRange.java
@@ -1,0 +1,94 @@
+package org.xproc.pep;
+
+public class CharacterRange {
+    private final int first;
+    private final int last;
+    private final boolean negated;
+
+    public CharacterRange(int first, int last, boolean negated) {
+        if (first < 0 || last < 0) {
+            throw new IllegalArgumentException("Character ranges cannot contain negative characters");
+        }
+        if (last < first) {
+            throw new IllegalArgumentException("Last character in a range must not precede the first character");
+        }
+        this.first = first;
+        this.last = last;
+        this.negated = negated;
+    }
+
+    public CharacterRange(int charnum, boolean negated) {
+        this(charnum, charnum, negated);
+    }
+
+    public CharacterRange(int first, int last) {
+        this(first, last, false);
+    }
+
+    public CharacterRange(int charnum) {
+        this(charnum, charnum, false);
+    }
+
+    public CharacterRange(char first, char last, boolean negated) {
+        this((int) first, (int) last, negated);
+    }
+
+    public CharacterRange(char first, char last) {
+        this((int) first, (int) last, false);
+    }
+
+    public CharacterRange(char first) {
+        this((int) first, (int) first, false);
+    }
+
+    public int getFirst() {
+        return first;
+    }
+
+    public int getLast() {
+        return last;
+    }
+
+    public boolean getNegated() {
+        return negated;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof CharacterRange) {
+            CharacterRange range = (CharacterRange) obj;
+            return first == range.first && last == range.last && negated == range.negated;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        if (negated) {
+            sb.append("^");
+        }
+        if (Character.isBmpCodePoint(first)) {
+            sb.append((char) first);
+        } else if (Character.isValidCodePoint(first)) {
+            sb.append(Character.highSurrogate(first));
+            sb.append(Character.lowSurrogate(first));
+        } else {
+            sb.append("???");
+        }
+        if (first != last) {
+            sb.append("-");
+            if (Character.isBmpCodePoint(last)) {
+                sb.append((char) last);
+            } else if (Character.isValidCodePoint(last)) {
+                sb.append(Character.highSurrogate(last));
+                sb.append(Character.lowSurrogate(last));
+            } else {
+                sb.append("???");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/xproc/pep/EarleyParser.java
+++ b/src/main/java/org/xproc/pep/EarleyParser.java
@@ -457,6 +457,11 @@ public class EarleyParser {
 					if(chart.addEdge(successor, newEdge)) {
 						fireEdgeScanned(successor, newEdge);
 					}
+					if (edge.dottedRule.activeCategory.isRepeatable()) {
+						if(chart.addEdge(successor, edge)) {
+							fireEdgeScanned(successor, newEdge);
+						}
+					}
 				}
 			}
 		}

--- a/src/main/java/org/xproc/pep/Edge.java
+++ b/src/main/java/org/xproc/pep/Edge.java
@@ -127,9 +127,7 @@ public class Edge {
 			return false;
 		}
 
-		return ignoreCase
-			? dottedRule.activeCategory.name.equalsIgnoreCase(token)
-			: dottedRule.activeCategory.name.equals(token);
+		return dottedRule.activeCategory.matches(token, ignoreCase);
 	}
 	
 	/**

--- a/src/main/java/org/xproc/pep/Grammar.java
+++ b/src/main/java/org/xproc/pep/Grammar.java
@@ -131,9 +131,7 @@ public class Grammar {
 			boolean ignoreCase) {
 		if(rules.containsKey(left)) {
 			for(Rule r : rules.get(left)) {
-				if(r.isSingletonPreterminal() && (r.right[0].name.equals(token)
-					|| (ignoreCase
-							&& r.right[0].name.equalsIgnoreCase(token)))) {
+				if(r.isSingletonPreterminal() && r.right[0].matches(token, ignoreCase)) {
 					return r;
 				}
 			}

--- a/src/test/java/org/xproc/pep/CategoryCharacterSetTest.java
+++ b/src/test/java/org/xproc/pep/CategoryCharacterSetTest.java
@@ -1,0 +1,63 @@
+package org.xproc.pep;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class CategoryCharacterSetTest extends PepFixture {
+    public void testEquality() {
+        CharacterRange alpha = new CharacterRange('A', 'Z');
+        CharacterRange digits = new CharacterRange('0', '9');
+        CategoryCharacterSet set1 = new CategoryCharacterSet("test", Arrays.asList(alpha, digits));
+        CategoryCharacterSet set2 = new CategoryCharacterSet("test", Arrays.asList(digits, alpha));
+        assertTrue(set1.equals(set2));
+    }
+
+    public void testInequality() {
+        CharacterRange alpha = new CharacterRange('A', 'Z');
+        CharacterRange digits = new CharacterRange('0', '9');
+        CategoryCharacterSet set1 = new CategoryCharacterSet("test", Arrays.asList(alpha));
+        CategoryCharacterSet set2 = new CategoryCharacterSet("test", Arrays.asList(digits));
+        assertFalse(set1.equals(set2));
+    }
+
+    public void testMatchesInRange() {
+        CharacterRange alpha = new CharacterRange('A', 'Z');
+        CharacterRange digits = new CharacterRange('0', '9');
+        CategoryCharacterSet set1 = new CategoryCharacterSet("test", Arrays.asList(digits, alpha));
+        assertTrue(set1.matches("A", false));
+        assertTrue(set1.matches("M", false));
+        assertTrue(set1.matches("Z", false));
+        assertTrue(set1.matches("0", false));
+        assertTrue(set1.matches("5", false));
+        assertTrue(set1.matches("9", false));
+        assertFalse(set1.matches("a", false));
+        assertFalse(set1.matches("!", false));
+    }
+
+    public void testMatchesNotInRange() {
+        CharacterRange alpha = new CharacterRange('A', 'Z', true);
+        CategoryCharacterSet set1 = new CategoryCharacterSet("test", Collections.singletonList(alpha));
+        assertFalse(set1.matches("A", false));
+        assertFalse(set1.matches("M", false));
+        assertFalse(set1.matches("Z", false));
+        assertTrue(set1.matches("0", false));
+        assertTrue(set1.matches("5", false));
+        assertTrue(set1.matches("9", false));
+        assertTrue(set1.matches("a", false));
+        assertTrue(set1.matches("!", false));
+    }
+
+    public void testMatchesIgnoreCase() {
+        CharacterRange alpha = new CharacterRange('A', 'Z');
+        CharacterRange digits = new CharacterRange('0', '9');
+        CategoryCharacterSet set1 = new CategoryCharacterSet("test", Arrays.asList(digits, alpha));
+        assertTrue(set1.matches("a", true));
+        assertTrue(set1.matches("m", true));
+        assertTrue(set1.matches("z", true));
+        assertTrue(set1.matches("0", true));
+        assertTrue(set1.matches("5", true));
+        assertTrue(set1.matches("9", true));
+        assertFalse(set1.matches("\u2611", true));
+        assertFalse(set1.matches("!", true));
+    }
+}

--- a/src/test/java/org/xproc/pep/CategorySetTest.java
+++ b/src/test/java/org/xproc/pep/CategorySetTest.java
@@ -1,0 +1,75 @@
+package org.xproc.pep;
+
+import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class CategorySetTest extends PepFixture {
+
+    public void testVowels() {
+        Grammar grammar = new Grammar("vowels");
+
+        Category z = new Category("z", true);
+        Category avz = new Category("a_vowel_z");
+        Category avsz = new Category("a_vowels_z");
+        Category vcv = new Category("v_c_v");
+        grammar.addRule(new Rule(vcv, Vowel, Consonant, Vowels));
+        grammar.addRule(new Rule(avz, a, Vowel, z));
+        grammar.addRule(new Rule(avsz, a, Vowels, z));
+
+        EarleyParser parser = new EarleyParser(grammar);
+
+        List<String> aOz = Arrays.asList("a", "O", "z");
+        List<String> aIEOz = Arrays.asList("a", "I", "E", "O", "z");
+        List<String> aEz = Arrays.asList("a", "E", "z");
+        List<String> abz = Arrays.asList("a", "b", "z");
+        List<String> AbO = Arrays.asList("A", "b", "O");
+        List<String> EbI = Arrays.asList("E", "b", "I");
+
+        try {
+            Parse parse = parser.parse(aIEOz, avsz);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+            parse = parser.parse(aOz, avz);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+            parse = parser.parse(aEz, avz);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+            parse = parser.parse(abz, avz);
+            Assert.assertTrue(parse.getStatus() == Status.REJECT);
+            parse = parser.parse(AbO, vcv);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+            parse = parser.parse(EbI, vcv);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+    public void testCharacterRanges() {
+        Grammar grammar = new Grammar("charranges");
+
+        CharacterRange upperAlpha = new CharacterRange('A', 'Z');
+        CharacterRange lowerAlpha = new CharacterRange('a', 'z');
+        CategoryCharacterSet alphas = new CategoryCharacterSet("alpha", Arrays.asList(upperAlpha, lowerAlpha), true);
+
+        CategoryCharacterSet digits = new CategoryCharacterSet("digits", Collections.singletonList(new CharacterRange('0', '9')));
+
+        Category digitLettersDigit = new Category("dld");
+
+        grammar.addRule(new Rule(digitLettersDigit, digits, alphas, digits));
+
+        EarleyParser parser = new EarleyParser(grammar);
+
+        List<String> zabc = Arrays.asList("0", "a", "b", "c", "X", "Y", "Z", "9");
+
+        try {
+            Parse parse = parser.parse(zabc, digitLettersDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+}

--- a/src/test/java/org/xproc/pep/CategoryTest.java
+++ b/src/test/java/org/xproc/pep/CategoryTest.java
@@ -12,6 +12,8 @@ package org.xproc.pep;
 
 import org.junit.Assert;
 
+import java.util.Arrays;
+
 
 /**
  * @author <a href="http://www.ling.osu.edu/~scott/">Scott Martin</a>
@@ -58,6 +60,7 @@ public class CategoryTest extends PepFixture {
 	 */
 	public final void testGetName() {
 		Assert.assertEquals("A", A.getName());
+		Assert.assertEquals("Vowels", Vowels.getName());
 	}
 
 	/**
@@ -66,6 +69,7 @@ public class CategoryTest extends PepFixture {
 	public final void testIsTerminal() {
 		Assert.assertEquals(false, A.isTerminal());
 		Assert.assertEquals(true, a.isTerminal());
+		Assert.assertEquals(true, Vowels.isTerminal());
 	}
 
 	/**
@@ -74,6 +78,12 @@ public class CategoryTest extends PepFixture {
 	public final void testEqualsObject() {
 		Assert.assertEquals(A, new Category("A", false));
 		Assert.assertFalse(A.equals(new Category("B")));
+		Assert.assertFalse(A.equals(Vowels));
+
+		CategorySet vowels = new CategorySet("Vowels", Arrays.asList("A", "E", "I", "O", "U"));
+		CategorySet someVowels = new CategorySet("Vowels", Arrays.asList("A", "E"));
+		Assert.assertTrue(Vowels.equals(vowels));
+		Assert.assertFalse(Vowels.equals(someVowels));
 	}
 
 	/**
@@ -82,5 +92,4 @@ public class CategoryTest extends PepFixture {
 	public final void testToString() {
 		Assert.assertEquals("A", A.toString());
 	}
-
 }

--- a/src/test/java/org/xproc/pep/CharacterRangeTest.java
+++ b/src/test/java/org/xproc/pep/CharacterRangeTest.java
@@ -1,0 +1,61 @@
+package org.xproc.pep;
+
+public class CharacterRangeTest extends PepFixture {
+    public void testAlphaRange() {
+        CharacterRange alpha = new CharacterRange('A', 'Z');
+        assertEquals((int) 'A', alpha.getFirst());
+        assertEquals((int) 'Z', alpha.getLast());
+        assertEquals(false, alpha.getNegated());
+    }
+
+    public void testNotAlphaRange() {
+        CharacterRange alpha = new CharacterRange('A', 'Z', true);
+        assertEquals((int) 'A', alpha.getFirst());
+        assertEquals((int) 'Z', alpha.getLast());
+        assertEquals(true, alpha.getNegated());
+    }
+
+    public void testSingleChar() {
+        CharacterRange alpha = new CharacterRange('A');
+        assertEquals((int) 'A', alpha.getFirst());
+        assertEquals((int) 'A', alpha.getLast());
+        assertEquals(false, alpha.getNegated());
+    }
+
+    public void testNotSingleChar() {
+        CharacterRange alpha = new CharacterRange('A', 'A', true);
+        assertEquals((int) 'A', alpha.getFirst());
+        assertEquals((int) 'A', alpha.getLast());
+        assertEquals(true, alpha.getNegated());
+    }
+
+    public void testNegativeStart() {
+        try {
+            CharacterRange alpha = new CharacterRange(-34, 100);
+            fail();
+        } catch (IllegalArgumentException ex) {
+        }
+    }
+
+    public void testNegativeRange() {
+        try {
+            CharacterRange alpha = new CharacterRange('9', '0');
+            fail();
+        } catch (IllegalArgumentException ex) {
+        }
+    }
+
+    public void testHigherRange() {
+        CharacterRange boxes = new CharacterRange(0x2610, 0x2611);
+        assertEquals(0x2610, boxes.getFirst());
+        assertEquals(0x2611, boxes.getLast());
+        assertEquals(false, boxes.getNegated());
+    }
+
+    public void testNotHigherRange() {
+        CharacterRange boxes = new CharacterRange(0x2610, 0x2611, true);
+        assertEquals(0x2610, boxes.getFirst());
+        assertEquals(0x2611, boxes.getLast());
+        assertEquals(true, boxes.getNegated());
+    }
+}

--- a/src/test/java/org/xproc/pep/PepFixture.java
+++ b/src/test/java/org/xproc/pep/PepFixture.java
@@ -10,10 +10,11 @@
  */
 package org.xproc.pep;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -23,6 +24,7 @@ import junit.framework.TestCase;
 public abstract class PepFixture extends TestCase {
 	Grammar grammar, mixed;
 	Category A, B, C, D, E, X, Y, Z, a, b;
+	Category Vowel, Vowels, Consonant, Consonants, Zero_to_Nine;
 	Category seed, S, NP, VP, Det, N, the, boy, girl, left;
 	Rule rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8;
 	Edge edge1, edge2, edge3;
@@ -42,7 +44,13 @@ public abstract class PepFixture extends TestCase {
 		Z = new Category("Z", false);
 		a = new Category("a", true);
 		b = new Category("b", true);
-		
+
+		Vowel = new CategorySet("Vowel", Arrays.asList("A", "E", "I", "O", "U"));
+		Vowels = new CategorySet("Vowels", Arrays.asList("A", "E", "I", "O", "U"), false, true);
+		Consonant = new CategorySet("Consonant", Arrays.asList("A", "E", "I", "O", "U"), true, false);
+		Consonants = new CategorySet("Consonants", Arrays.asList("A", "E", "I", "O", "U"), true, true);
+		Zero_to_Nine = new CategorySet("Zero_to_Nine", Arrays.asList("0","1","2","3","4","5","6","7","8","9"));
+
 		rule1 = new Rule(A, B, C, D, E);
 		rule2 = new Rule(A, a);
 		rule3 = new Rule(X, Y, Z);


### PR DESCRIPTION
This PR adds support for several features.

1. A new class `CategorySet` is a terminal that matches any one of a number of tokens, or the negation of that set.
2. A new class `CategoryCharacterSet` that matches a character range, or the negation of that range.
3. A new class `CharacterRange` that represents a range of Unicode code points.

