### PR TITLE
Support optionality in category matching

### DIFF
--- a/src/main/java/org/xproc/pep/Category.java
+++ b/src/main/java/org/xproc/pep/Category.java
@@ -33,7 +33,7 @@ package org.xproc.pep;
 public class Category {
 	String name;
 	boolean terminal;
-	boolean repeatable;
+	boolean optional;
 	
 	/**
 	 * Special start category for seeding Earley parsers. 
@@ -76,11 +76,11 @@ public class Category {
 	 * status.
 	 * @param name The name for this category.
 	 * @param terminal Whether or not this category is a terminal.
-	 * @param repeatable Whether or not this category can be repeated.
+	 * @param optional Whether or not this category can be repeated.
 	 * @throws IllegalArgumentException If <code>name</code> is
 	 * <code>null</code> or zero-length.
 	 */
-	public Category(String name, boolean terminal, boolean repeatable) {
+	public Category(String name, boolean terminal, boolean optional) {
 		if(!terminal && (name == null || name.length() == 0)) {
 			throw new IllegalArgumentException(
 					"empty name specified for category");
@@ -88,9 +88,9 @@ public class Category {
 		
 		this.name = name;
 		this.terminal = terminal;
-		this.repeatable = repeatable;
+		this.optional = optional;
 	}
-	
+
 	/**
 	 * Gets the name of this category.
 	 * @return The value specified for this category's name when it was
@@ -110,12 +110,12 @@ public class Category {
 	}
 
 	/**
-	 * Gets the repeatable status of this category.
-	 * @return The repeatable status specified for this category upon
+	 * Gets the optional status of this category.
+	 * @return The optional status specified for this category upon
 	 * construction.
 	 */
-	public boolean isRepeatable() {
-		return repeatable;
+	public boolean isOptional() {
+		return optional;
 	}
 
 	/**

--- a/src/main/java/org/xproc/pep/CategoryCharacterSet.java
+++ b/src/main/java/org/xproc/pep/CategoryCharacterSet.java
@@ -1,48 +1,143 @@
+/*
+ * Copyright (C) 2021 Norman Walsh
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version. The GNU Lesser General Public License is
+ * distributed with this software in the file COPYING.
+ */
 package org.xproc.pep;
 
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * A special kind of {@link Category category} that represents sets of characters.
+ *
+ * <p>This extension allows PEP to recognize ranges of Unicode characters.</p>
+ *
+ * <p>Where a simple terminal {@link Category} matches only a single token, the
+ * <code>CategoryCharacterClass</code> matches any character that satisfies a range.
+ * For example, you could make a character set that matched any
+ * of the digits from 0 to 9 or any vowel.</p>
+ *
+ * <p>Character sets are composed from a union of {@link CharacterSet} ranges.</p>
+ *
+ * <p>A set can be an <em>inclusion</em>, where it matches any character that appears
+ * in any range, or an <em>exclusion</em>, where it matches any character that does
+ * not appear in <em>any</em> range.</p>
+ *
+ * <p>For example, given <code>letters</code>, a range representing any Unicode character
+ * in the "letter" class, and <code>digits</code>, a range representing the digits "0" to "9", inclusive:</p>
+ * <ul>
+ *     <li><code>CategoryCharacterSet.inclusion("letters", letters)</code> matches any letter.</li>
+ *     <li><code>CategoryCharacterSet.exclusion("not-letters", letters)</code> matches any character
+ *     that is not a letter.</li>
+ *     <li><code>CategoryCharacterSet.inclusion("letters-or-digits", Arrays.asList(letters, digits)</code> matches
+ *     any letter or digit.</li>
+ * </ul>
+ *
+ * <p>If you ask whether a single character matches a set, the answer is obvious. If you ask whether a string
+ * of characters matches, it's less obvious. At present, this class takes the position that any token
+ * of more than one Unicode code point <em>does not match</em> any set. An alternative would be to say that
+ * it matches if each and all of its characters match. Please raise an issue or a pull-request if you'd prefer
+ * that interpretation. I don't feel strongly about it.</p>
+ */
+
 public class CategoryCharacterSet extends Category {
     private final List<CharacterSet> ranges;
     private final boolean inclusion;
 
-    private CategoryCharacterSet(String name, List<CharacterSet> ranges, boolean inclusion, boolean repeatable) {
-        super(name, true, repeatable);
+    private CategoryCharacterSet(String name, List<CharacterSet> ranges, boolean inclusion, boolean optional) {
+        super(name, true, optional);
         this.ranges = ranges;
         this.inclusion = inclusion;
     }
 
+    /**
+     * Construct a category for the given range.
+     * <p>This is a convenience class for the case where you want to match a single range.</p>
+     * @param name The name of the category.
+     * @param range The range.
+     * @return A character set {@link Category} that matches any character in that range.
+     */
     public static CategoryCharacterSet inclusion(String name, CharacterSet range) {
         return new CategoryCharacterSet(name, Collections.singletonList(range), true, false);
     }
 
+    /**
+     * Construct a category for the given set of ranges.
+     * @param name The name of the category.
+     * @param ranges The ranges.
+     * @return A character set {@link Category} that matches any character in any range.
+     */
     public static CategoryCharacterSet inclusion(String name, List<CharacterSet> ranges) {
         return new CategoryCharacterSet(name, ranges, true, false);
     }
 
-    public static CategoryCharacterSet inclusion(String name, CharacterSet range, boolean repeatable) {
-        return new CategoryCharacterSet(name, Collections.singletonList(range), true, repeatable);
+    /**
+     * Construct a category for an optional character in the given range.
+     * <p>This is a convenience class for the case where you want to match a single range.</p>
+     * @param name The name of the category.
+     * @param range The range.
+     * @return A character set {@link Category} that optionally matches any character in that range.
+     */
+    public static CategoryCharacterSet inclusion(String name, CharacterSet range, boolean optional) {
+        return new CategoryCharacterSet(name, Collections.singletonList(range), true, optional);
     }
 
-    public static CategoryCharacterSet inclusion(String name, List<CharacterSet> ranges, boolean repeatable) {
-        return new CategoryCharacterSet(name, ranges, true, repeatable);
+    /**
+     * Construct a category for an optional character in the given range.
+     * <p>This is a convenience class for the case where you want to match a single range.</p>
+     * @param name The name of the category.
+     * @param ranges The ranges.
+     * @return A character set {@link Category} that optionally matches any character in that range.
+     */
+    public static CategoryCharacterSet inclusion(String name, List<CharacterSet> ranges, boolean optional) {
+        return new CategoryCharacterSet(name, ranges, true, optional);
     }
 
+    /**
+     * Construct a category excluding the given range.
+     * <p>This is a convenience class for the case where you want to match a single range.</p>
+     * @param name The name of the category.
+     * @param range The range.
+     * @return A character set {@link Category} that matches any character <em>not</em> in the range.
+     */
     public static CategoryCharacterSet exclusion(String name, CharacterSet range) {
         return new CategoryCharacterSet(name, Collections.singletonList(range), false, false);
     }
 
+    /**
+     * Construct a category excluding the given range.
+     * @param name The name of the category.
+     * @param ranges The range.
+     * @return A character set {@link Category} that matches any character <em>not</em> in the range.
+     */
     public static CategoryCharacterSet exclusion(String name, List<CharacterSet> ranges) {
         return new CategoryCharacterSet(name, ranges, false, false);
     }
 
-    public static CategoryCharacterSet exclusion(String name, CharacterSet range, boolean repeatable) {
-        return new CategoryCharacterSet(name, Collections.singletonList(range), false, repeatable);
+    /**
+     * Construct a category for an optional character excluded from the given range.
+     * <p>This is a convenience class for the case where you want to match a single range.</p>
+     * @param name The name of the category.
+     * @param range The range.
+     * @return A character set {@link Category} that matches any character <em>not</em> in the range.
+     */
+    public static CategoryCharacterSet exclusion(String name, CharacterSet range, boolean optional) {
+        return new CategoryCharacterSet(name, Collections.singletonList(range), false, optional);
     }
 
-    public static CategoryCharacterSet exclusion(String name, List<CharacterSet> ranges, boolean repeatable) {
-        return new CategoryCharacterSet(name, ranges, false, repeatable);
+    /**
+     * Construct a category for an optional character excluded from the given range.
+     * @param name The name of the category.
+     * @param ranges The range.
+     * @return A character set {@link Category} that matches any character <em>not</em> in the range.
+     */
+    public static CategoryCharacterSet exclusion(String name, List<CharacterSet> ranges, boolean optional) {
+        return new CategoryCharacterSet(name, ranges, false, optional);
     }
 
     /**

--- a/src/main/java/org/xproc/pep/CategorySet.java
+++ b/src/main/java/org/xproc/pep/CategorySet.java
@@ -1,28 +1,80 @@
+/*
+ * Copyright (C) 2021 Norman Walsh
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version. The GNU Lesser General Public License is
+ * distributed with this software in the file COPYING.
+ */
 package org.xproc.pep;
 
 import java.util.HashMap;
 import java.util.List;
 
+/**
+ * A special kind of {@link Category category} that represents sets of tokens.
+ *
+ * <p>This extension allows PEP to recognize sets of strings with a single {@link Category}.</p>
+ *
+ * <p>Where a simple terminal {@link Category} matches only a single token, a
+ * <code>CategorySet</code> matches any of a set of strings.
+ * <p>For example, you could make a set that matched "January", "February", "March", ...</p>
+ *
+ * <p>A set can be an <em>inclusion</em>, where it matches any string that appears
+ * in the set, or an <em>exclusion</em>, where it matches any string that does
+ * not appear in the set.</p>
+ */
 public class CategorySet extends Category {
     private final boolean negated;
     private final List<String> tokens;
 
-    public CategorySet(String name, List<String> tokens, boolean negated, boolean repeatable) {
-        super(name, true, repeatable);
+    private CategorySet(String name, List<String> tokens, boolean negated, boolean optional) {
+        super(name, true, optional);
         this.tokens = tokens;
         this.negated = negated;
     }
 
-    public CategorySet(String name, List<String> tokens, boolean negated) {
-        super(name, true, false);
-        this.tokens = tokens;
-        this.negated = negated;
+    /**
+     * Create a set that matches any one of a set of tokens.
+     * @param name The category name.
+     * @param tokens The list of tokens.
+     * @return A category that matches any one of those tokens.
+     */
+    public static CategorySet inclusion(String name, List<String> tokens) {
+        return new CategorySet(name, tokens, false, false);
     }
 
-    public CategorySet(String name, List<String> tokens) {
-        super(name, true);
-        this.tokens = tokens;
-        negated = false;
+    /**
+     * Create a set that optionally matches any one of a set of tokens.
+     * @param name The category name.
+     * @param tokens The list of tokens.
+     * @param optional Whether or not the category is optional.
+     * @return A category that optionally matches any one of those tokens.
+     */
+    public static CategorySet inclusion(String name, List<String> tokens, boolean optional) {
+        return new CategorySet(name, tokens, false, optional);
+    }
+
+    /**
+     * Create a set that matches any string except a set of tokens.
+     * @param name The category name.
+     * @param tokens The list of tokens.
+     * @return A category that matches any string except one of the specified tokens.
+     */
+    public static CategorySet exclusion(String name, List<String> tokens) {
+        return new CategorySet(name, tokens, true, false);
+    }
+
+    /**
+     * Create a set that optionally matches any string except a set of tokens.
+     * @param name The category name.
+     * @param tokens The list of tokens.
+     * @param optional Whether or not the category is optional.
+     * @return A category that matches any string except one of the specified tokens.
+     */
+    public static CategorySet exclusion(String name, List<String> tokens, boolean optional) {
+        return new CategorySet(name, tokens, false, optional);
     }
 
     /**

--- a/src/main/java/org/xproc/pep/CharacterSet.java
+++ b/src/main/java/org/xproc/pep/CharacterSet.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright (C) 2021 Norman Walsh
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version. The GNU Lesser General Public License is
+ * distributed with this software in the file COPYING.
+ */
 package org.xproc.pep;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+/**
+ * A class that represents a range of Unicode characters.
+ * <p>Ranges can be constructed from a literal string, from a range of Unicode codepoints, or
+ * via Unicode character classes.</p>
+ */
 public class CharacterSet {
     private String charClass = null;
     private Pattern pattern = null;
@@ -39,23 +53,43 @@ public class CharacterSet {
         } else {
             this.charClass = charclass.toString() + subclass;
         }
-        this.pattern = Pattern.compile("\\p{" + charClass + "}");
+        String patn = "\\" + "p{" + charClass + "}";
+        this.pattern = Pattern.compile(patn);
     }
 
+    /**
+     * Construct a character set containing each of the characters in the string.
+     * @param literal The string of characters.
+     * @return A character set that will match each of those characters.
+     */
     public static CharacterSet literal(String literal) {
         return new CharacterSet(literal);
     }
 
+    /**
+     * Construct a character set containing each of the characters in the specified range, inclusive.
+     * @param first The first codepoint.
+     * @param last The last codepoint.
+     * @return A character set that will match each of those characters.
+     * @throws IllegalArgumentException if the range is invalid.
+     */
     public static CharacterSet range(int first, int last) {
         return new CharacterSet(first, last);
     }
 
+    /**
+     * Construct a character set representing the specified Unicode character class.
+     * @param charClass The character class, for example "L", or "Nd".
+     * @return A character set that will match characters in that class.
+     * @throws NullPointerException if the charClass is null.
+     * @throws IllegalArgumentException if the charClass is less than 1 or more than 2 characters long.
+     */
     public static CharacterSet unicodeClass(String charClass) {
         if (charClass == null) {
             throw new NullPointerException("Null charClass");
         }
-        if (charClass.length() > 2) {
-            throw new IllegalArgumentException("The charClass can be at most two characters");
+        if (charClass.length() < 1 || charClass.length() > 2) {
+            throw new IllegalArgumentException("The charClass must be one or two characters");
         }
         Character ch1 = charClass.charAt(0);
         Character ch2 = null;
@@ -65,6 +99,14 @@ public class CharacterSet {
         return new CharacterSet(ch1, ch2);
     }
 
+    /**
+     * Tests for the equality of two <code>CharacterSet</code> objects.
+     * <p>Two <code>CharacterSet</code> objects are equal only if they identify the same characters
+     * expressed in the same way. A set created from the literal "0123456789" is not equal to
+     * a set created from the range '0' to '9'.</p>
+     * @param obj A CharacterSet to test for equality against.
+     * @return true if and only if the character set provided identifies the same range of characters.
+     */
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof CharacterSet) {
@@ -78,11 +120,15 @@ public class CharacterSet {
         return false;
     }
 
+    /**
+     * Test if a code point occurs in the set.
+     * @param codepoint The Unicode codepoint to test.
+     * @return true if and only if the codepoint is in the set.
+     */
     public boolean matches(int codepoint) {
         if (pattern != null) {
             String str = new StringBuilder().appendCodePoint(codepoint).toString();
-            boolean match = pattern.matcher(str).matches();
-            return match;
+            return pattern.matcher(str).matches();
         } else if (codepoints != null) {
             return codepoints.contains(codepoint);
         } else {

--- a/src/main/java/org/xproc/pep/DottedRule.java
+++ b/src/main/java/org/xproc/pep/DottedRule.java
@@ -126,7 +126,18 @@ public class DottedRule extends Rule {
 	public Category getActiveCategory() {
 		return activeCategory;
 	}
-	
+
+	/**
+	 * Tests if the active charcter is an optional category.
+	 * @return true if and only if the active category exists and is optional.
+	 */
+	public boolean atOptionalCategory() {
+		if (activeCategory == null) {
+			return false;
+		}
+		return activeCategory.isOptional();
+	}
+
 	/**
 	 * Tests whether this dotted rule is equal to another dotted rule by
 	 * comparing their underlying rules and dot positions.

--- a/src/main/java/org/xproc/pep/EarleyParser.java
+++ b/src/main/java/org/xproc/pep/EarleyParser.java
@@ -447,20 +447,25 @@ public class EarleyParser {
 					}
 				}
 			}
-			
+
 			for(Edge edge : edges.toArray(new Edge[edges.size()])) {
 				// completions for active edges only
-				if(edge.canScan(token, ignoreCase)) {
-					Edge newEdge = Edge.scan(edge, token, ignoreCase);
-					Integer successor // save next index
-						= new Integer(index.intValue() + 1); 
-					if(chart.addEdge(successor, newEdge)) {
-						fireEdgeScanned(successor, newEdge);
-					}
-					if (edge.dottedRule.activeCategory.isRepeatable()) {
-						if(chart.addEdge(successor, edge)) {
+				// when considering an edge, if it is currently positioned at an optional
+				// category, also consider the edge where that optional cateogry has been skipped.
+				boolean skipOptional = true;
+				Edge thisEdge = edge;
+				while (skipOptional) {
+					if(thisEdge.canScan(token, ignoreCase)) {
+						Edge newEdge = Edge.scan(thisEdge, token, ignoreCase);
+						Integer successor // save next index
+								= new Integer(index.intValue() + 1);
+						if(chart.addEdge(successor, newEdge)) {
 							fireEdgeScanned(successor, newEdge);
 						}
+					}
+					skipOptional = thisEdge.atOptionalCategory();
+					if (skipOptional) {
+						thisEdge = Edge.skipOptionalToken(thisEdge);
 					}
 				}
 			}
@@ -498,6 +503,18 @@ public class EarleyParser {
 									// if the chart did not already contain this edge
 									fireEdgeCompleted(index, newEdge);									
 									completeStack.push(newEdge);
+								}
+
+								// if the new edge is positioned at an optional category, also consider
+								// the edge where that optional category has been skipped.
+								while (newEdge.atOptionalCategory()) {
+									newEdge = Edge.skipOptionalToken(newEdge);
+									if(chart.addEdge(index, newEdge)) {
+										// only notify and recursively complete
+										// if the chart did not already contain this edge
+										fireEdgeCompleted(index, newEdge);
+										completeStack.push(newEdge);
+									}
 								}
 							}
 						}

--- a/src/main/java/org/xproc/pep/Edge.java
+++ b/src/main/java/org/xproc/pep/Edge.java
@@ -129,6 +129,14 @@ public class Edge {
 
 		return dottedRule.activeCategory.matches(token, ignoreCase);
 	}
+
+	/**
+	 * Tests if the current edge is positioned at an optional category.
+	 * @return true if and only if the edge is positioned at an optional category.
+	 */
+	public boolean atOptionalCategory() {
+		return dottedRule.atOptionalCategory();
+	}
 	
 	/**
 	 * Creates an edge based on the given edge and the token that was just
@@ -174,6 +182,21 @@ public class Edge {
 		Edge scanEdge = new Edge(DottedRule.advanceDot(edge.dottedRule), edge.origin);
 		scanEdge.bases = Edge.addBasisEdge(edge, edge);
 		
+		return scanEdge;
+	}
+
+	public static Edge skipOptionalToken(Edge edge) {
+		if(edge == null) {
+			throw new NullPointerException("null edge");
+		}
+
+		if(!edge.atOptionalCategory()) {
+			throw new IllegalArgumentException("cannot skip a non-optional token");
+		}
+
+		Edge scanEdge = new Edge(DottedRule.advanceDot(edge.dottedRule), edge.origin);
+		scanEdge.bases = Edge.addBasisEdge(edge, edge);
+
 		return scanEdge;
 	}
 

--- a/src/test/java/org/xproc/pep/CategoryOptionalTest.java
+++ b/src/test/java/org/xproc/pep/CategoryOptionalTest.java
@@ -1,0 +1,228 @@
+package org.xproc.pep;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+
+public class CategoryOptionalTest extends TestCase {
+
+    public void testOptionalTerminal() {
+        Grammar grammar = new Grammar("opt");
+
+        Category A = new Category("A");
+        Category B = new Category("B");
+        Category a = new Category("a", true);
+        Category b = new Category("b", true);
+        Category x = new Category("x", true, true);
+
+        Category opt = new Category("Opt");
+
+        grammar.addRule(new Rule(opt, A, x, B));
+        grammar.addRule(new Rule(A, a));
+        grammar.addRule(new Rule(B, b));
+
+        EarleyParser parser = new EarleyParser(grammar);
+        ArrayList<String> tokens = new ArrayList<>();
+        tokens.add("a");
+        //tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+    public void testOptionalNonterminal() {
+        Grammar grammar = new Grammar("opt");
+
+        Category A = new Category("A");
+        Category B = new Category("B");
+        Category X = new Category("X", false, true);
+        Category a = new Category("a", true);
+        Category b = new Category("b", true);
+        Category x = new Category("x", true);
+
+        Category opt = new Category("Opt");
+
+        grammar.addRule(new Rule(opt, A, X, B));
+        grammar.addRule(new Rule(A, a));
+        grammar.addRule(new Rule(B, b));
+        grammar.addRule(new Rule(X, x));
+
+        EarleyParser parser = new EarleyParser(grammar);
+        ArrayList<String> tokens = new ArrayList<>();
+        tokens.add("a");
+        //tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+    public void testOptionalRepeatedTerminal() {
+        Grammar grammar = new Grammar("opt");
+
+        Category A = new Category("A");
+        Category B = new Category("B");
+        Category a = new Category("a", true);
+        Category b = new Category("b", true);
+        Category x = new Category("x", true, true);
+
+        Category opt = new Category("Opt");
+
+        grammar.addRule(new Rule(opt, A, x, x, B));
+        grammar.addRule(new Rule(A, a));
+        grammar.addRule(new Rule(B, b));
+
+        EarleyParser parser = new EarleyParser(grammar);
+        ArrayList<String> tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.REJECT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+    public void testOptionalRepeatedNonterminal() {
+        Grammar grammar = new Grammar("opt");
+
+        Category A = new Category("A");
+        Category B = new Category("B");
+        Category X = new Category("X", false, true);
+        Category Y = new Category("Y", false, true);
+        Category Z = new Category("Z", false, true);
+        Category a = new Category("a", true);
+        Category b = new Category("b", true);
+        Category x = new Category("x", true);
+
+        Category opt = new Category("Opt");
+
+        grammar.addRule(new Rule(opt, A, X, B));
+        grammar.addRule(new Rule(opt, A, X, X, B));
+        grammar.addRule(new Rule(opt, A, X, Y, B));
+        grammar.addRule(new Rule(opt, A, X, Y, Z, B));
+        grammar.addRule(new Rule(A, a));
+        grammar.addRule(new Rule(B, b));
+        grammar.addRule(new Rule(X, x));
+        grammar.addRule(new Rule(Y, x));
+        grammar.addRule(new Rule(Z, x));
+
+        EarleyParser parser = new EarleyParser(grammar);
+        ArrayList<String> tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.ACCEPT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+
+        tokens = new ArrayList<>();
+        tokens.add("a");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("x");
+        tokens.add("b");
+
+        try {
+            Parse parse = parser.parse(tokens, opt);
+            Assert.assertEquals(Status.REJECT, parse.getStatus());
+        } catch (PepException ex) {
+            fail();
+        }
+    }
+
+}

--- a/src/test/java/org/xproc/pep/CategorySetTest.java
+++ b/src/test/java/org/xproc/pep/CategorySetTest.java
@@ -15,23 +15,20 @@ public class CategorySetTest extends PepFixture {
         Category avz = new Category("a_vowel_z");
         Category avsz = new Category("a_vowels_z");
         Category vcv = new Category("v_c_v");
-        grammar.addRule(new Rule(vcv, Vowel, Consonant, Vowels));
+        grammar.addRule(new Rule(vcv, Vowel, Consonant, Vowel));
         grammar.addRule(new Rule(avz, a, Vowel, z));
-        grammar.addRule(new Rule(avsz, a, Vowels, z));
+        grammar.addRule(new Rule(avsz, a, Vowel, z));
 
         EarleyParser parser = new EarleyParser(grammar);
 
         List<String> aOz = Arrays.asList("a", "O", "z");
-        List<String> aIEOz = Arrays.asList("a", "I", "E", "O", "z");
         List<String> aEz = Arrays.asList("a", "E", "z");
         List<String> abz = Arrays.asList("a", "b", "z");
         List<String> AbO = Arrays.asList("A", "b", "O");
         List<String> EbI = Arrays.asList("E", "b", "I");
 
         try {
-            Parse parse = parser.parse(aIEOz, avsz);
-            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
-            parse = parser.parse(aOz, avz);
+            Parse parse = parser.parse(aOz, avz);
             Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
             parse = parser.parse(aEz, avz);
             Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
@@ -54,20 +51,66 @@ public class CategorySetTest extends PepFixture {
         CategoryCharacterSet alphas = CategoryCharacterSet.inclusion("alpha", Arrays.asList(upperAlpha, lowerAlpha), true);
         CategoryCharacterSet digits = CategoryCharacterSet.inclusion("digits", Collections.singletonList(CharacterSet.range('0', '9')));
 
-        Category digitLettersDigit = new Category("dld");
+        Category digitLetterDigit = new Category("dld");
 
-        grammar.addRule(new Rule(digitLettersDigit, digits, alphas, digits));
+        grammar.addRule(new Rule(digitLetterDigit, digits, alphas, digits));
 
         EarleyParser parser = new EarleyParser(grammar);
 
-        List<String> zabc = Arrays.asList("0", "a", "b", "c", "X", "Y", "Z", "9");
-
+        List<String> zabc = Arrays.asList("0", "9");
         try {
-            Parse parse = parser.parse(zabc, digitLettersDigit);
+            Parse parse = parser.parse(zabc, digitLetterDigit);
             Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
         } catch (PepException ex) {
             fail();
         }
-    }
 
+        zabc = Arrays.asList("0", "a", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+
+        zabc = Arrays.asList("0", "a", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+
+        zabc = Arrays.asList("0", "A", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+
+        zabc = Arrays.asList("0", "z", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+
+        zabc = Arrays.asList("0", "Z", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertTrue(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+
+        zabc = Arrays.asList("0", "π", "9");
+        try {
+            Parse parse = parser.parse(zabc, digitLetterDigit);
+            Assert.assertFalse(parse.getStatus() == Status.ACCEPT);
+        } catch (PepException ex) {
+            fail();
+        }
+    }
 }

--- a/src/test/java/org/xproc/pep/CategoryTest.java
+++ b/src/test/java/org/xproc/pep/CategoryTest.java
@@ -60,7 +60,7 @@ public class CategoryTest extends PepFixture {
 	 */
 	public final void testGetName() {
 		Assert.assertEquals("A", A.getName());
-		Assert.assertEquals("Vowels", Vowels.getName());
+		Assert.assertEquals("Vowel", Vowel.getName());
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class CategoryTest extends PepFixture {
 	public final void testIsTerminal() {
 		Assert.assertEquals(false, A.isTerminal());
 		Assert.assertEquals(true, a.isTerminal());
-		Assert.assertEquals(true, Vowels.isTerminal());
+		Assert.assertEquals(true, Vowel.isTerminal());
 	}
 
 	/**
@@ -78,12 +78,12 @@ public class CategoryTest extends PepFixture {
 	public final void testEqualsObject() {
 		Assert.assertEquals(A, new Category("A", false));
 		Assert.assertFalse(A.equals(new Category("B")));
-		Assert.assertFalse(A.equals(Vowels));
+		Assert.assertFalse(A.equals(Vowel));
 
-		CategorySet vowels = new CategorySet("Vowels", Arrays.asList("A", "E", "I", "O", "U"));
-		CategorySet someVowels = new CategorySet("Vowels", Arrays.asList("A", "E"));
-		Assert.assertTrue(Vowels.equals(vowels));
-		Assert.assertFalse(Vowels.equals(someVowels));
+		CategorySet vowel = CategorySet.inclusion("Vowel", Arrays.asList("A", "E", "I", "O", "U"));
+		CategorySet someVowels = CategorySet.inclusion("Vowels", Arrays.asList("A", "E"));
+		Assert.assertTrue(Vowel.equals(vowel));
+		Assert.assertFalse(Vowel.equals(someVowels));
 	}
 
 	/**

--- a/src/test/java/org/xproc/pep/PepFixture.java
+++ b/src/test/java/org/xproc/pep/PepFixture.java
@@ -24,7 +24,7 @@ import java.util.List;
 public abstract class PepFixture extends TestCase {
 	Grammar grammar, mixed;
 	Category A, B, C, D, E, X, Y, Z, a, b;
-	Category Vowel, Vowels, Consonant, Consonants, Zero_to_Nine;
+	Category Vowel, Consonant, Zero_to_Nine;
 	Category seed, S, NP, VP, Det, N, the, boy, girl, left;
 	Rule rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8;
 	Edge edge1, edge2, edge3;
@@ -45,11 +45,9 @@ public abstract class PepFixture extends TestCase {
 		a = new Category("a", true);
 		b = new Category("b", true);
 
-		Vowel = new CategorySet("Vowel", Arrays.asList("A", "E", "I", "O", "U"));
-		Vowels = new CategorySet("Vowels", Arrays.asList("A", "E", "I", "O", "U"), false, true);
-		Consonant = new CategorySet("Consonant", Arrays.asList("A", "E", "I", "O", "U"), true, false);
-		Consonants = new CategorySet("Consonants", Arrays.asList("A", "E", "I", "O", "U"), true, true);
-		Zero_to_Nine = new CategorySet("Zero_to_Nine", Arrays.asList("0","1","2","3","4","5","6","7","8","9"));
+		Vowel = CategorySet.inclusion("Vowel", Arrays.asList("A", "E", "I", "O", "U"));
+		Consonant = CategorySet.exclusion("Consonant", Arrays.asList("A", "E", "I", "O", "U"));
+		Zero_to_Nine = CategorySet.inclusion("Zero_to_Nine", Arrays.asList("0","1","2","3","4","5","6","7","8","9"));
 
 		rule1 = new Rule(A, B, C, D, E);
 		rule2 = new Rule(A, a);


### PR DESCRIPTION
Fix #8 

Right. Assuming I didn't break anything (or everything), this version of PEP supports optional categories. It no longer supports repeatable categories because, as the issue observes, they can be represented easily with optionality and it seemed simpler not to have both mechanisms.

In principle, I don't think it would be hard to support both, but the API is a little more complicated.